### PR TITLE
Fix env example database name

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@ SECRET_KEY=your-secret-key-here  # Change this in production!
 POSTGRES_SERVER=localhost
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=your_password_here
-POSTGRES_DB=ai_societycd_2025_website_db
+POSTGRES_DB=ai_society_2025_website_db
 
 DATABASE_URL=postgresql+psycopg2://{DATABASE_USER}:{DATABASE_PASSWORD}@{DATABASE_SERVER}/{DATABASE_NAME}
 


### PR DESCRIPTION
## Summary
- fix typo in example env var for Postgres database

## Testing
- `python backend/test_apis.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683fc7da8b00832db9a055019591bdac