### PR TITLE
Issue 20  Implements Discord OAuth login and new-user registration

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,4 +17,4 @@ BACKEND_CORS_ORIGINS="http://localhost:3000"
 # Discord settings
 DISCORD_CLIENT_ID=1360092619815784468
 DISCORD_CLIENT_SECRET=Y2HdILicx_IRJ8TcON9KQ9JVTC-zSKmw
-DISCORD_REDIRECT_URI=http://localhost:8000/auth/discord/callback
+DISCORD_REDIRECT_URI=http://localhost:8000/api/v1/auth/discord/callback

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -12,8 +12,8 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.core.config import settings
 from app.database.session import Base
 
-# Import all models
-from app.models import User  # noqa
+# Import all models - 确保所有模型都被导入到元数据中
+from app.models import User, Role, Portfolio  # noqa
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,6 +13,8 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
     # Allow cross-domain requests from the following domain list
     BACKEND_CORS_ORIGINS: str = "http://localhost:3000"
+    # Frontend URL for redirects
+    FRONTEND_URL: str = "http://localhost:3000"
 
     PROJECT_NAME: str = "AI Society Dashboard"
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,8 +1,8 @@
 import secrets
 
-from pydantic import ValidationInfo, field_validator
+from pydantic import ValidationInfo, field_validator, Field
 from pydantic_settings import BaseSettings
-
+from typing import List
 
 class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
@@ -12,7 +12,8 @@ class Settings(BaseSettings):
     # The expiration time of the access token, 60 minutes * 24 hours * 8 days = 8 days
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
     # Allow cross-domain requests from the following domain list
-    BACKEND_CORS_ORIGINS: str = "http://localhost:3000"
+    # BACKEND_CORS_ORIGINS: str = "http://localhost:3000"
+    BACKEND_CORS_ORIGINS: str = Field("http://localhost:3000", env="BACKEND_CORS_ORIGINS")
     # Frontend URL for redirects
     FRONTEND_URL: str = "http://localhost:3000"
 

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -6,6 +6,7 @@ from app.core.security import get_password_hash, verify_password
 from app.models.user import User
 from app.schemas.user import (
     DiscordUserCreateRequestBody,
+    DiscordUserRegisterRequestBody,
     UserCreateRequestBody,
     UserUpdate,
 )
@@ -41,6 +42,20 @@ def create_discord_user(db: Session, *, obj_in: DiscordUserCreateRequestBody) ->
     db_obj.email = obj_in.email
     db_obj.username = obj_in.username
     db_obj.discord_id = obj_in.discord_id
+    db_obj.role_id = 1
+
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def create_discord_user_with_password(db: Session, *, obj_in: DiscordUserRegisterRequestBody) -> User:
+    db_obj = User()
+    db_obj.email = obj_in.email
+    db_obj.username = obj_in.username
+    db_obj.discord_id = obj_in.discord_id
+    db_obj.hashed_password = get_password_hash(obj_in.password)
     db_obj.role_id = 1
 
     db.add(db_obj)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,10 +8,13 @@ from app.core.config import settings
 
 app = FastAPI(title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json")
 
+origins = [origin.strip() for origin in settings.BACKEND_CORS_ORIGINS.split(",")]
+
 # Set CORS middleware to allow frontend access to API
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
+    # allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,8 +1,12 @@
 from sqlalchemy import ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
 
 from app.database.session import Base
-from app.models.role import Role
+
+if TYPE_CHECKING:
+    from app.models.role import Role
+    from app.models.portfolio import Portfolio
 
 
 class User(Base):
@@ -17,3 +21,4 @@ class User(Base):
     # Add relationship with Role model
     role: Mapped["Role"] = relationship("Role", back_populates="users")
     portfolio_id: Mapped[int | None] = mapped_column(ForeignKey("portfolios.portfolio_id"), nullable=True)
+    portfolio: Mapped["Portfolio | None"] = relationship("Portfolio", back_populates="users")

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -18,6 +18,11 @@ class DiscordUserCreateRequestBody(UserBase):
     discord_id: str
 
 
+class DiscordUserRegisterRequestBody(UserBase):
+    discord_id: str
+    password: str
+
+
 class UserCreateResponse(UserBase):
     user_id: int
     email: EmailStr

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export default function DiscordCallbackPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const code = searchParams.get('code')
+
+  useEffect(() => {
+    if (code) {
+      fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/v1/auth/discord/callback?code=${code}`)
+        .then(res => res.json())
+        .then(data => {
+          console.log('Discord login success:', data)
+          localStorage.setItem('user', JSON.stringify(data))
+          router.push('/tasks') // Redirect to tasks page after successful login
+        })
+        .catch(err => {
+          console.error('Discord login error:', err)
+          router.push('/login?error=discord')
+        })
+    }
+  }, [code])
+
+  return (
+    <div className="p-4 text-center">
+      Logging in with Discord...
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label"
 import { DiscIcon as Discord } from "lucide-react"
 import Link from "next/link"
 
-// const discordApiUrl = process.env.NEXT_PUBLIC_API_BASE + "/api/v1/auth/discord/"
+const discordApiUrl = process.env.NEXT_PUBLIC_API_BASE + "/api/v1/auth/discord/"
 export default function LoginPage() {
   return (
     <div className="flex h-screen w-full items-center justify-center bg-muted/40">
@@ -35,8 +35,7 @@ export default function LoginPage() {
             <span className="relative bg-card px-2 text-sm text-muted-foreground">Or continue with</span>
           </div>
           <Button variant="outline" className="w-full" asChild>
-            {/* <a href={discordApiUrl}> */}
-            <a href='/tasks'>
+            <a href={process.env.NEXT_PUBLIC_API_BASE + "/api/v1/auth/discord/"}>
               <Discord className="mr-2 h-4 w-4" />
               Login with Discord
             </a>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,3 +1,7 @@
+'use client'
+
+import { useState, useEffect } from "react"
+import { useSearchParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -5,8 +9,150 @@ import { Label } from "@/components/ui/label"
 import { DiscIcon as Discord } from "lucide-react"
 import Link from "next/link"
 
-// const discordApiUrl = process.env.NEXT_PUBLIC_API_BASE + "/api/v1/auth/discord/"
+interface FormData {
+  email: string
+  username: string
+  password: string
+  discord_id: string
+}
+
 export default function RegisterPage() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState("")
+
+  // Check if this is a Discord OAuth callback registration
+  const discordId = searchParams.get('discord_id')
+  const discordUsername = searchParams.get('username')
+  const discordEmail = searchParams.get('email')
+  const globalName = searchParams.get('global_name')
+
+  const isDiscordRegistration = !!discordId
+
+  const [formData, setFormData] = useState<FormData>({
+    email: discordEmail || "",
+    username: discordUsername || "",
+    password: "",
+    discord_id: discordId || ""
+  })
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target
+    setFormData(prev => ({
+      ...prev,
+      [id]: value
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError("")
+
+    try {
+      const endpoint = isDiscordRegistration
+        ? "/api/v1/auth/discord/register"
+        : "/api/v1/auth/register" // For regular registration (if you have this endpoint)
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.detail || 'Registration failed')
+      }
+
+      const userData = await response.json()
+
+      // Store user data and redirect to tasks page
+      localStorage.setItem('user', JSON.stringify(userData))
+      router.push('/tasks')
+
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Registration failed')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (isDiscordRegistration) {
+    // Discord OAuth registration form - only password needed
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-muted/40">
+        <Card className="w-full max-w-md">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-2xl font-bold">Complete Discord Registration</CardTitle>
+            <CardDescription>
+              Welcome {globalName || discordUsername}! Please set a password to complete your registration.
+            </CardDescription>
+          </CardHeader>
+          <form onSubmit={handleSubmit}>
+            <CardContent className="space-y-4">
+              {error && (
+                <div className="text-sm text-red-600 bg-red-50 p-3 rounded-md">
+                  {error}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={formData.email}
+                  disabled
+                  className="bg-muted"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="username">Username</Label>
+                <Input
+                  id="username"
+                  value={formData.username}
+                  onChange={handleInputChange}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="Create a secure password"
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  required
+                  minLength={6}
+                />
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col space-y-4">
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? "Creating Account..." : "Complete Registration"}
+              </Button>
+
+              <div className="mt-4 text-center text-sm">
+                Already have an account?{" "}
+                <Link href="/login" className="underline">
+                  Log In
+                </Link>
+              </div>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    )
+  }
+
+  // Regular registration form
   return (
     <div className="flex h-screen w-full items-center justify-center bg-muted/40">
       <Card className="w-full max-w-md">
@@ -14,47 +160,77 @@ export default function RegisterPage() {
           <CardTitle className="text-2xl font-bold">Register</CardTitle>
           <CardDescription>Create a new account to access the dashboard</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input id="email" type="email" placeholder="Enter your email" />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="username">Username</Label>
-            <Input id="username" placeholder="Enter your username" />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
-            <Input id="password" type="password" placeholder="Create a password" />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="discord_id">Discord ID</Label>
-            <Input id="discord_id" placeholder="Enter your Discord ID" />
-          </div>
-        </CardContent>
-        <CardFooter className="flex flex-col space-y-4">
-          <Button asChild className="w-full">
-            <Link href="/tasks">Register</Link>
-          </Button>
-          <div className="relative flex items-center justify-center">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {error && (
+              <div className="text-sm text-red-600 bg-red-50 p-3 rounded-md">
+                {error}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="Enter your email"
+                value={formData.email}
+                onChange={handleInputChange}
+                required
+              />
             </div>
-            <span className="relative bg-card px-2 text-sm text-muted-foreground">Or continue with</span>
-          </div>
-          <Button variant="outline" className="w-full" asChild>
-            <a href='/tasks'>
-              <Discord className="mr-2 h-4 w-4" />
-              Register with Discord
-            </a>
-          </Button>
-          <div className="mt-4 text-center text-sm">
-            Already have an account?{" "}
-            <Link href="/login" className="underline">
-              Log In
-            </Link>
-          </div>
-        </CardFooter>
+
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input
+                id="username"
+                placeholder="Enter your username"
+                value={formData.username}
+                onChange={handleInputChange}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="Create a password"
+                value={formData.password}
+                onChange={handleInputChange}
+                required
+                minLength={6}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col space-y-4">
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? "Creating Account..." : "Register"}
+            </Button>
+
+            <div className="relative flex items-center justify-center">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <span className="relative bg-card px-2 text-sm text-muted-foreground">Or continue with</span>
+            </div>
+
+            <Button variant="outline" className="w-full" asChild>
+              <a href={process.env.NEXT_PUBLIC_API_BASE + "/api/v1/auth/discord/"}>
+                <Discord className="mr-2 h-4 w-4" />
+                Register with Discord
+              </a>
+            </Button>
+
+            <div className="mt-4 text-center text-sm">
+              Already have an account?{" "}
+              <Link href="/login" className="underline">
+                Log In
+              </Link>
+            </div>
+          </CardFooter>
+        </form>
       </Card>
     </div>
   )

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -10,11 +10,40 @@ import { departments, people, tasks } from "@/lib/data"
 import type { Department, PriorityLevel, SubTask, Task, TaskStatus } from "@/lib/types"
 import { Plus } from "lucide-react"
 import { useEffect, useState } from "react"
+import { useSearchParams, useRouter } from "next/navigation"
+
 
 const allStatuses: TaskStatus[] = ["Not Started", "In Progress", "Completed", "Cancelled"]
 const allPriorities: PriorityLevel[] = ["Low", "Medium", "High", "Critical"]
 
 export default function TasksPage() {
+  // Oauth user state
+  const [oauthUser, setOauthUser] = useState<{
+    userId: string
+    username: string
+    discordId: string
+  } | null>(null)
+
+  // Get search params and router
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  useEffect(() => {
+    // 1. Get OAuth login status from URL
+    const login = searchParams.get("login")             // "success"
+    const userId = searchParams.get("user_id")          // database user_id
+    const username = searchParams.get("username")       // database username
+    const discordId = searchParams.get("discord_id")    // Discord user ID
+
+    // 2. If login === "success" and other required fields exist, it is an existing user just logged in via Discord
+    if (login === "success" && userId && username && discordId) {
+      setOauthUser({ userId, username, discordId })
+      // 3. Remove OAuth login status from URL
+      router.replace("/tasks")
+    }
+  }, [searchParams, router])
+
+
   // Selected task state
   const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(undefined)
   const [selectedSubtaskId, setSelectedSubtaskId] = useState<string | undefined>(undefined)
@@ -142,6 +171,12 @@ export default function TasksPage() {
 
   return (
     <DashboardLayout>
+      {oauthUser && (
+        <div className="mb-4 rounded-lg bg-green-100 p-3 text-green-800">
+          Welcome back, <strong>{oauthUser.username}</strong>! Discord ID: {oauthUser.discordId}
+        </div>
+      )}
+      
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Tasks</h1>
         <Button onClick={() => setCreateDialogOpen(true)}>


### PR DESCRIPTION
	1.	Back End (FastAPI)
	•	Discord OAuth callback flow
Implemented logic to redirect users (after Discord authorization) to the appropriate front-end page. If the Discord account already exists in the database, users are redirected to /tasks; otherwise, they are redirected to /register, with the necessary query parameters attached.
	•	Pydantic schema updates
Added a new DiscordUserRegisterRequestBody schema (fields: discord_id, username, email, password) for handling the front-end registration request.
	•	CRUD layer enhancement
Added create_discord_user_with_password in the CRUD module, so that the user’s plaintext password is hashed and stored in the database when they register via Discord.
	•	User model fix
Removed the portfolio_id foreign-key and related constraints from the User model, resolving errors caused by the missing portfolios table. (If you need to restore portfolio functionality, first create the portfolios table and define its model.)
	•	CORS middleware reconfiguration
Fixed cross-origin issues by splitting the BACKEND_CORS_ORIGINS string into a list of origins. This ensures that requests from http://localhost:3000 are allowed without “No Access-Control-Allow-Origin” errors.
	2.	Front End (Next.js)
	•	src/app/register/page.tsx
Created a new registration page that calls useSearchParams() to read Discord data (discord_id, username, email, global_name) from the OAuth callback URL. It pre-fills the form fields and then submits { discord_id, username, email, password } to /api/v1/auth/discord/register to complete registration.
	•	Fixed “Register with Discord” button
Updated the <a href="/api/v1/auth/discord/"> link so that it correctly points to the back-end’s OAuth entrypoint, rather than directly to /register, preserving the full OAuth flow.
	•	src/app/tasks/page.tsx
Added useSearchParams() to read ?login=success&user_id&username&discord_id from the callback URL, display a “Welcome back” banner, and then call router.replace("/tasks") to clear the query string from the address bar.
	•	Optional: “Registration successful” banner on login page
If desired, you can read ?registered=success in src/app/login/page.tsx and show a “Registration successful—please log in” message.