### PR TITLE
Meeting manage page

### DIFF
--- a/backend/alembic/versions/002_add_user_can_see_field_to_meeting_record.py
+++ b/backend/alembic/versions/002_add_user_can_see_field_to_meeting_record.py
@@ -1,0 +1,27 @@
+"""Add user_can_see field to meeting_record table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-01-08 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Upgrade the database schema"""
+    # Add user_can_see column to meeting_records table
+    op.add_column('meeting_records', sa.Column('user_can_see', sa.Boolean(), nullable=False, server_default='true'))
+
+
+def downgrade():
+    """Downgrade the database schema"""
+    # Remove user_can_see column from meeting_records table
+    op.drop_column('meeting_records', 'user_can_see') 

--- a/backend/app/api/api_v1/endpoints/meeting_records.py
+++ b/backend/app/api/api_v1/endpoints/meeting_records.py
@@ -27,7 +27,12 @@ def create_meeting_record(
     Create new meeting record
     """
     meeting_rec = meeting_record.create_meeting_record(db, obj_in=meeting_in)
-    return MeetingRecordResponse(**meeting_rec.__dict__)
+    # Reload with portfolio to get portfolio_name
+    meeting_rec = meeting_record.get_by_id(db, meeting_id=meeting_rec.meeting_id)
+    
+    response_data = MeetingRecordResponse(**meeting_rec.__dict__)
+    response_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
+    return response_data
 
 
 @router.get("/{meeting_id}", response_model=MeetingRecordDetailResponse)
@@ -49,6 +54,7 @@ def read_meeting_record(
 
     meeting_data = MeetingRecordDetailResponse(**meeting_rec.__dict__)
     meeting_data.related_tasks_count = related_tasks_count
+    meeting_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
     return meeting_data
 
 
@@ -85,6 +91,7 @@ def read_meeting_records(
         meeting_data = MeetingRecordListResponse(**meeting_rec.__dict__)
         meeting_data.has_recording = bool(meeting_rec.recording_file_link)
         meeting_data.has_summary = bool(meeting_rec.summary)
+        meeting_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
         result.append(meeting_data)
 
     return result
@@ -106,7 +113,12 @@ def update_meeting_record(
         raise HTTPException(status_code=404, detail="Meeting record not found")
 
     meeting_rec = meeting_record.update_meeting_record(db, db_obj=meeting_rec, obj_in=meeting_in)
-    return MeetingRecordResponse(**meeting_rec.__dict__)
+    # Reload with portfolio to ensure we have the latest data
+    meeting_rec = meeting_record.get_by_id(db, meeting_id=meeting_rec.meeting_id)
+    
+    response_data = MeetingRecordResponse(**meeting_rec.__dict__)
+    response_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
+    return response_data
 
 
 @router.delete("/{meeting_id}")
@@ -156,6 +168,7 @@ def read_meeting_records_by_portfolio(
         meeting_data = MeetingRecordListResponse(**meeting_rec.__dict__)
         meeting_data.has_recording = bool(meeting_rec.recording_file_link)
         meeting_data.has_summary = bool(meeting_rec.summary)
+        meeting_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
         result.append(meeting_data)
 
     return result
@@ -185,6 +198,7 @@ def read_meeting_records_with_recordings(
         meeting_data = MeetingRecordListResponse(**meeting_rec.__dict__)
         meeting_data.has_recording = True  # Always true for this endpoint
         meeting_data.has_summary = bool(meeting_rec.summary)
+        meeting_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
         result.append(meeting_data)
 
     return result
@@ -214,6 +228,7 @@ def read_meeting_records_with_summaries(
         meeting_data = MeetingRecordListResponse(**meeting_rec.__dict__)
         meeting_data.has_recording = bool(meeting_rec.recording_file_link)
         meeting_data.has_summary = True  # Always true for this endpoint
+        meeting_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
         result.append(meeting_data)
 
     return result
@@ -242,6 +257,7 @@ def search_meeting_records(
         meeting_data = MeetingRecordListResponse(**meeting_rec.__dict__)
         meeting_data.has_recording = bool(meeting_rec.recording_file_link)
         meeting_data.has_summary = bool(meeting_rec.summary)
+        meeting_data.portfolio_name = meeting_rec.portfolio.name if meeting_rec.portfolio else None
         result.append(meeting_data)
 
     return result

--- a/backend/app/crud/meeting_record.py
+++ b/backend/app/crud/meeting_record.py
@@ -4,6 +4,8 @@ from sqlalchemy import func, and_, or_
 from datetime import date
 
 from app.models.meeting_record import MeetingRecord
+from app.models.user import User
+from app.models.portfolio import Portfolio
 from app.schemas.meeting_record import MeetingRecordCreateRequestBody, MeetingRecordUpdate
 
 
@@ -83,6 +85,98 @@ def get_multi(
     return query.order_by(MeetingRecord.meeting_date.desc()).offset(skip).limit(limit).all()
 
 
+def get_multi_with_permissions(
+    db: Session,
+    *,
+    current_user: User,
+    portfolio_id: int | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    has_recording: bool | None = None,
+    has_summary: bool | None = None,
+    skip: int = 0,
+    limit: int = 100
+) -> list[MeetingRecord]:
+    """Get multiple meeting records with permission-based filtering"""
+    query = db.query(MeetingRecord)
+    
+    # Apply permission-based filtering based on user role
+    if current_user.role_id == 2:  # Admin - can see all meetings
+        pass  # No additional filtering needed
+    elif current_user.role_id == 3:  # Director - can see all meetings in their portfolios
+        # Get all portfolios where this director is responsible
+        # For now, assuming director can see all portfolios they have access to
+        # This might need to be adjusted based on your business logic
+        if current_user.portfolio_id:
+            query = query.filter(MeetingRecord.portfolio_id == current_user.portfolio_id)
+        else:
+            # If director has no portfolio assigned, they can't see any meetings
+            query = query.filter(MeetingRecord.meeting_id == -1)  # Always false
+    else:  # Regular user - can only see meetings in their portfolio where user_can_see is True
+        if current_user.portfolio_id:
+            query = query.filter(
+                and_(
+                    MeetingRecord.portfolio_id == current_user.portfolio_id,
+                    MeetingRecord.user_can_see == True
+                )
+            )
+        else:
+            # If user has no portfolio assigned, they can't see any meetings
+            query = query.filter(MeetingRecord.meeting_id == -1)  # Always false
+    
+    # Apply additional filters
+    if portfolio_id:
+        query = query.filter(MeetingRecord.portfolio_id == portfolio_id)
+    
+    if start_date and end_date:
+        query = query.filter(
+            and_(
+                MeetingRecord.meeting_date >= start_date,
+                MeetingRecord.meeting_date <= end_date
+            )
+        )
+    elif start_date:
+        query = query.filter(MeetingRecord.meeting_date >= start_date)
+    elif end_date:
+        query = query.filter(MeetingRecord.meeting_date <= end_date)
+    
+    if has_recording is True:
+        query = query.filter(MeetingRecord.recording_file_link.isnot(None))
+    elif has_recording is False:
+        query = query.filter(MeetingRecord.recording_file_link.is_(None))
+    
+    if has_summary is True:
+        query = query.filter(MeetingRecord.summary.isnot(None))
+    elif has_summary is False:
+        query = query.filter(MeetingRecord.summary.is_(None))
+    
+    return query.order_by(MeetingRecord.meeting_date.desc()).offset(skip).limit(limit).all()
+
+
+def get_by_id_with_permissions(db: Session, meeting_id: int, current_user: User) -> MeetingRecord | None:
+    """Get meeting record by ID with permission check"""
+    meeting = db.query(MeetingRecord).filter(MeetingRecord.meeting_id == meeting_id).first()
+    
+    if not meeting:
+        return None
+    
+    # Apply permission-based filtering
+    if current_user.role_id == 2:  # Admin - can see all meetings
+        return meeting
+    elif current_user.role_id == 3:  # Director - can see all meetings in their portfolios
+        if current_user.portfolio_id and meeting.portfolio_id == current_user.portfolio_id:
+            return meeting
+        else:
+            return None
+    else:  # Regular user - can only see meetings in their portfolio where user_can_see is True
+        if (current_user.portfolio_id and 
+            meeting.portfolio_id == current_user.portfolio_id and 
+            meeting.user_can_see):
+            return meeting
+        else:
+            return None
+
+
 def create_meeting_record(db: Session, *, obj_in: MeetingRecordCreateRequestBody) -> MeetingRecord:
     """Create new meeting record"""
     db_obj = MeetingRecord()
@@ -92,6 +186,7 @@ def create_meeting_record(db: Session, *, obj_in: MeetingRecordCreateRequestBody
     db_obj.auto_caption = obj_in.auto_caption
     db_obj.summary = obj_in.summary
     db_obj.portfolio_id = obj_in.portfolio_id
+    db_obj.user_can_see = obj_in.user_can_see
 
     db.add(db_obj)
     db.commit()
@@ -128,6 +223,47 @@ def delete_meeting_record(db: Session, *, meeting_id: int) -> bool:
 def search_meeting_records(db: Session, *, search_term: str, portfolio_id: int | None = None) -> list[MeetingRecord]:
     """Search meeting records by name or summary"""
     query = db.query(MeetingRecord)
+    
+    if portfolio_id:
+        query = query.filter(MeetingRecord.portfolio_id == portfolio_id)
+    
+    search_filter = or_(
+        MeetingRecord.meeting_name.ilike(f"%{search_term}%"),
+        MeetingRecord.summary.ilike(f"%{search_term}%"),
+        MeetingRecord.auto_caption.ilike(f"%{search_term}%")
+    )
+    
+    return query.filter(search_filter).order_by(MeetingRecord.meeting_date.desc()).all()
+
+
+def search_meeting_records_with_permissions(
+    db: Session, 
+    *, 
+    search_term: str, 
+    current_user: User,
+    portfolio_id: int | None = None
+) -> list[MeetingRecord]:
+    """Search meeting records by name or summary with permission filtering"""
+    query = db.query(MeetingRecord)
+    
+    # Apply permission-based filtering based on user role
+    if current_user.role_id == 2:  # Admin - can see all meetings
+        pass  # No additional filtering needed
+    elif current_user.role_id == 3:  # Director - can see all meetings in their portfolios
+        if current_user.portfolio_id:
+            query = query.filter(MeetingRecord.portfolio_id == current_user.portfolio_id)
+        else:
+            query = query.filter(MeetingRecord.meeting_id == -1)  # Always false
+    else:  # Regular user - can only see meetings in their portfolio where user_can_see is True
+        if current_user.portfolio_id:
+            query = query.filter(
+                and_(
+                    MeetingRecord.portfolio_id == current_user.portfolio_id,
+                    MeetingRecord.user_can_see == True
+                )
+            )
+        else:
+            query = query.filter(MeetingRecord.meeting_id == -1)  # Always false
     
     if portfolio_id:
         query = query.filter(MeetingRecord.portfolio_id == portfolio_id)

--- a/backend/app/models/meeting_record.py
+++ b/backend/app/models/meeting_record.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Optional
-from sqlalchemy import ForeignKey, String, Text, Integer, DateTime
+from sqlalchemy import ForeignKey, String, Text, DateTime, Boolean
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from datetime import datetime
 from app.database.session import Base
@@ -18,6 +18,7 @@ class MeetingRecord(Base):
     auto_caption: Mapped[str | None] = mapped_column(Text, nullable=True)
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     portfolio_id: Mapped[int] = mapped_column(ForeignKey("portfolios.portfolio_id"), nullable=False)
+    user_can_see: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
     # Relationships
     portfolio: Mapped["Portfolio"] = relationship("Portfolio", back_populates="meeting_records")

--- a/backend/app/schemas/meeting_record.py
+++ b/backend/app/schemas/meeting_record.py
@@ -35,6 +35,7 @@ class MeetingRecordUpdate(BaseModel):
 # Used for API responses
 class MeetingRecordResponse(MeetingRecordBase):
     meeting_id: int
+    portfolio_name: str | None = None
     
     class Config:
         from_attributes = True
@@ -49,6 +50,8 @@ class MeetingRecordListResponse(BaseModel):
     user_can_see: bool
     has_recording: bool = False  # Computed field
     has_summary: bool = False    # Computed field
+    summary: str | None = None   # Added summary field
+    portfolio_name: str | None = None  # Added portfolio_name field
     
     class Config:
         from_attributes = True

--- a/backend/app/schemas/meeting_record.py
+++ b/backend/app/schemas/meeting_record.py
@@ -10,6 +10,7 @@ class MeetingRecordBase(BaseModel):
     auto_caption: str | None = None
     summary: str | None = None
     portfolio_id: int
+    user_can_see: bool = True
 
 
 # Used when creating a meeting record
@@ -17,6 +18,7 @@ class MeetingRecordCreateRequestBody(MeetingRecordBase):
     meeting_date: date
     meeting_name: str
     portfolio_id: int
+    user_can_see: bool = True
 
 
 # Used when updating a meeting record
@@ -27,6 +29,7 @@ class MeetingRecordUpdate(BaseModel):
     auto_caption: str | None = None
     summary: str | None = None
     portfolio_id: int | None = None
+    user_can_see: bool | None = None
 
 
 # Used for API responses
@@ -43,6 +46,7 @@ class MeetingRecordListResponse(BaseModel):
     meeting_date: date
     meeting_name: str
     portfolio_id: int
+    user_can_see: bool
     has_recording: bool = False  # Computed field
     has_summary: bool = False    # Computed field
     

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "next": "^15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -6417,6 +6418,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "next": "^15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/frontend/src/app/(internal)/taskbot/layout.tsx
+++ b/frontend/src/app/(internal)/taskbot/layout.tsx
@@ -1,6 +1,6 @@
+import TaskbotLayoutClient from "@/components/joyui/task/TaskbotLayoutClient";
 import { UserProvider } from "@/components/providers/UserProvider";
 import { getCurrentUser } from "@/lib/session";
-import TaskbotLayoutClient from "@/components/joyui/task/TaskbotLayoutClient";
 
 export default async function TaskbotLayout({ children }: { children: React.ReactNode }) {
   const userResponse = await getCurrentUser().catch(() => null);

--- a/frontend/src/app/(internal)/taskbot/meetings/[meeting_id]/page.tsx
+++ b/frontend/src/app/(internal)/taskbot/meetings/[meeting_id]/page.tsx
@@ -1,0 +1,71 @@
+import MeetingDetailClient from "@/components/joyui/meeting/MeetingDetailClient";
+import { getMeetingRecordById, getTasksByMeeting } from "@/lib/api/meetingRecord";
+import { getAllPortfolios } from "@/lib/api/permissions";
+import { Box, CircularProgress, Typography } from "@mui/joy";
+import { Suspense } from "react";
+
+interface MeetingDetailPageProps {
+  params: {
+    meeting_id: string;
+  };
+}
+
+async function MeetingDetailData({ meetingId }: { meetingId: number }) {
+  try {
+    const [meetingDetails, relatedTasks, portfolios] = await Promise.all([
+      getMeetingRecordById(meetingId),
+      getTasksByMeeting(meetingId),
+      getAllPortfolios()
+    ]);
+
+    return (
+      <MeetingDetailClient
+        meeting={meetingDetails}
+        relatedTasks={relatedTasks}
+        portfolios={portfolios}
+      />
+    );
+  } catch (error) {
+    console.error("Error fetching meeting details:", error);
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography color="danger">
+          Failed to load meeting details. Please try again later.
+        </Typography>
+      </Box>
+    );
+  }
+}
+
+function MeetingDetailLoadingState() {
+  return (
+    <Box sx={{ 
+      display: "flex", 
+      justifyContent: "center", 
+      alignItems: "center", 
+      minHeight: "50vh" 
+    }}>
+      <CircularProgress />
+    </Box>
+  );
+}
+
+export default function MeetingDetailPage({ params }: MeetingDetailPageProps) {
+  const meetingId = parseInt(params.meeting_id);
+
+  if (isNaN(meetingId)) {
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography color="danger">
+          Invalid meeting ID
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Suspense fallback={<MeetingDetailLoadingState />}>
+      <MeetingDetailData meetingId={meetingId} />
+    </Suspense>
+  );
+} 

--- a/frontend/src/app/(internal)/taskbot/meetings/[meeting_id]/page.tsx
+++ b/frontend/src/app/(internal)/taskbot/meetings/[meeting_id]/page.tsx
@@ -26,32 +26,28 @@ async function MeetingDetailData({ meetingId }: { meetingId: number }) {
       />
     );
   } catch (error) {
-    console.error("Error fetching meeting details:", error);
+    console.error("Error fetching meeting detail data:", error);
     return (
       <Box sx={{ textAlign: "center", py: 4 }}>
         <Typography color="danger">
-          Failed to load meeting details. Please try again later.
+          Failed to load meeting details. Please try again.
         </Typography>
       </Box>
     );
   }
 }
 
-function MeetingDetailLoadingState() {
+function MeetingDetailLoading() {
   return (
-    <Box sx={{ 
-      display: "flex", 
-      justifyContent: "center", 
-      alignItems: "center", 
-      minHeight: "50vh" 
-    }}>
+    <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
       <CircularProgress />
     </Box>
   );
 }
 
-export default function MeetingDetailPage({ params }: MeetingDetailPageProps) {
-  const meetingId = parseInt(params.meeting_id);
+export default async function MeetingDetailPage({ params }: MeetingDetailPageProps) {
+  const { meeting_id } = await params;
+  const meetingId = parseInt(meeting_id);
 
   if (isNaN(meetingId)) {
     return (
@@ -64,8 +60,10 @@ export default function MeetingDetailPage({ params }: MeetingDetailPageProps) {
   }
 
   return (
-    <Suspense fallback={<MeetingDetailLoadingState />}>
-      <MeetingDetailData meetingId={meetingId} />
-    </Suspense>
+    <Box sx={{ p: 3 }}>
+      <Suspense fallback={<MeetingDetailLoading />}>
+        <MeetingDetailData meetingId={meetingId} />
+      </Suspense>
+    </Box>
   );
 } 

--- a/frontend/src/app/(internal)/taskbot/meetings/page.tsx
+++ b/frontend/src/app/(internal)/taskbot/meetings/page.tsx
@@ -1,0 +1,56 @@
+import MeetingListClient from "@/components/joyui/meeting/MeetingListClient";
+import { getMeetingRecords } from "@/lib/api/meetingRecord";
+import { getAllPortfolios } from "@/lib/api/permissions";
+import { Box, CircularProgress, Typography } from "@mui/joy";
+import { Suspense } from "react";
+
+async function MeetingData() {
+  try {
+    const [meetingRecords, portfolios] = await Promise.all([
+      getMeetingRecords(),
+      getAllPortfolios()
+    ]);
+
+    return (
+      <MeetingListClient 
+        initialMeetings={meetingRecords} 
+        portfolios={portfolios}
+      />
+    );
+  } catch (error) {
+    console.error("Error fetching meeting data:", error);
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography color="danger">
+          Failed to load meetings. Please try again later.
+        </Typography>
+      </Box>
+    );
+  }
+}
+
+function MeetingLoadingState() {
+  return (
+    <Box sx={{ 
+      display: "flex", 
+      justifyContent: "center", 
+      alignItems: "center", 
+      minHeight: "50vh" 
+    }}>
+      <CircularProgress />
+    </Box>
+  );
+}
+
+export default function MeetingsPage() {
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography level="h1" sx={{ mb: 3 }}>
+        Meetings
+      </Typography>
+      <Suspense fallback={<MeetingLoadingState />}>
+        <MeetingData />
+      </Suspense>
+    </Box>
+  );
+} 

--- a/frontend/src/components/joyui/meeting/MeetingCard.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingCard.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { MeetingRecordListResponse } from "@/lib/types";
+import { Box, Card, CardContent, Chip, Typography } from "@mui/joy";
+
+interface MeetingCardProps {
+  meeting: MeetingRecordListResponse;
+  portfolioName: string;
+  onClick: () => void;
+}
+
+export default function MeetingCard({ 
+  meeting, 
+  portfolioName, 
+  onClick 
+}: MeetingCardProps) {
+  const formatDate = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    } catch (error) {
+      return dateString;
+    }
+  };
+
+  const getPortfolioColor = (portfolio: string) => {
+    switch (portfolio.toLowerCase()) {
+      case 'product':
+        return 'primary';
+      case 'marketing':
+        return 'success';
+      case 'finance':
+        return 'warning';
+      default:
+        return 'neutral';
+    }
+  };
+
+  return (
+    <Card 
+      variant="outlined" 
+      sx={{ 
+        cursor: 'pointer',
+        transition: 'all 0.2s',
+        '&:hover': {
+          boxShadow: 'md',
+          transform: 'translateY(-2px)'
+        }
+      }}
+      onClick={onClick}
+    >
+      <CardContent>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
+          <Typography level="title-md" sx={{ fontWeight: 'bold' }}>
+            {meeting.meeting_name}
+          </Typography>
+          <Chip 
+            variant="soft" 
+            color={getPortfolioColor(portfolioName)}
+            size="sm"
+          >
+            {portfolioName}
+          </Chip>
+        </Box>
+        
+        <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
+          {formatDate(meeting.meeting_date)}
+        </Typography>
+        
+        {meeting.summary && (
+          <Typography 
+            level="body-sm" 
+            sx={{ 
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              lineHeight: 1.4
+            }}
+          >
+            {meeting.summary}
+          </Typography>
+        )}
+        
+        <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+          {meeting.has_recording && (
+            <Chip variant="soft" color="success" size="sm">
+              Recording
+            </Chip>
+          )}
+          {meeting.has_summary && (
+            <Chip variant="soft" color="primary" size="sm">
+              Summary
+            </Chip>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+} 

--- a/frontend/src/components/joyui/meeting/MeetingCard.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingCard.tsx
@@ -30,16 +30,7 @@ export default function MeetingCard({
   };
 
   const getPortfolioColor = (portfolio: string) => {
-    switch (portfolio.toLowerCase()) {
-      case 'edu':
-        return 'primary';
-      case 'it portfolio':
-        return 'success';
-      case 'marketing':
-        return 'warning';
-      default:
-        return 'neutral';
-    }
+    return 'primary' as const;
   };
 
   return (
@@ -110,19 +101,7 @@ export default function MeetingCard({
           </Typography>
         </Box>
 
-        {/* Status indicators */}
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 'auto' }}>
-          {meeting.has_recording && (
-            <Chip size="sm" color="success" variant="soft">
-              Recording
-            </Chip>
-          )}
-          {meeting.has_summary && (
-            <Chip size="sm" color="primary" variant="soft">
-              Summary
-            </Chip>
-          )}
-        </Box>
+
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/joyui/meeting/MeetingCard.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingCard.tsx
@@ -18,19 +18,15 @@ export default function MeetingCard({
     try {
       const date = new Date(dateString);
       return date.toLocaleDateString('en-US', {
-        year: 'numeric',
         month: 'short',
         day: 'numeric',
+        year: 'numeric',
         hour: '2-digit',
         minute: '2-digit'
       });
     } catch (error) {
       return dateString;
     }
-  };
-
-  const getPortfolioColor = (portfolio: string) => {
-    return 'primary' as const;
   };
 
   return (
@@ -40,68 +36,78 @@ export default function MeetingCard({
       sx={{
         cursor: 'pointer',
         transition: 'all 0.2s ease-in-out',
-        height: '240px', // Fixed height
-        display: 'flex',
-        flexDirection: 'column',
+        height: '190px',
         '&:hover': {
           boxShadow: 'md',
           transform: 'translateY(-2px)',
         },
       }}
     >
-      <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        {/* Header with portfolio and date */}
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+      <CardContent sx={{ 
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        p: 2,
+        gap: 1
+      }}>
+        {/* Header: Portfolio and Date */}
+        <Box sx={{ 
+          display: 'flex', 
+          justifyContent: 'space-between', 
+          alignItems: 'center',
+          mb: 0.5
+        }}>
           <Chip
-            color={getPortfolioColor(portfolioName)}
+            color="primary"
             size="sm"
             variant="soft"
-            sx={{ flexShrink: 0 }}
           >
             {portfolioName}
           </Chip>
-          <Typography level="body-sm" color="neutral" sx={{ flexShrink: 0 }}>
+          <Typography 
+            level="body-xs" 
+            color="neutral"
+            sx={{ fontSize: '0.75rem' }}
+          >
             {formatDate(meeting.meeting_date)}
           </Typography>
         </Box>
 
-        {/* Meeting title */}
+        {/* Meeting Title */}
         <Typography 
-          level="title-md" 
+          level="title-md"
           sx={{ 
             fontWeight: 'bold',
+            lineHeight: 1.2,
             display: '-webkit-box',
             WebkitLineClamp: 2,
             WebkitBoxOrient: 'vertical',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            lineHeight: 1.4,
-            minHeight: '2.8em', // Reserve space for 2 lines
+            mb: 1
           }}
         >
           {meeting.meeting_name}
         </Typography>
 
         {/* Summary */}
-        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ flex: 1, overflow: 'hidden' }}>
           <Typography 
             level="body-sm" 
             color="neutral"
             sx={{ 
+              lineHeight: 1.4,
               display: '-webkit-box',
-              WebkitLineClamp: 4,
+              WebkitLineClamp: 3,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
-              lineHeight: 1.5,
-              flex: 1,
+              fontSize: '0.875rem'
             }}
           >
             {meeting.summary || 'No summary available'}
           </Typography>
         </Box>
-
-
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/joyui/meeting/MeetingCard.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingCard.tsx
@@ -31,11 +31,11 @@ export default function MeetingCard({
 
   const getPortfolioColor = (portfolio: string) => {
     switch (portfolio.toLowerCase()) {
-      case 'product':
+      case 'edu':
         return 'primary';
-      case 'marketing':
+      case 'it portfolio':
         return 'success';
-      case 'finance':
+      case 'marketing':
         return 'warning';
       default:
         return 'neutral';
@@ -43,60 +43,82 @@ export default function MeetingCard({
   };
 
   return (
-    <Card 
-      variant="outlined" 
-      sx={{ 
+    <Card
+      variant="outlined"
+      onClick={onClick}
+      sx={{
         cursor: 'pointer',
-        transition: 'all 0.2s',
+        transition: 'all 0.2s ease-in-out',
+        height: '240px', // Fixed height
+        display: 'flex',
+        flexDirection: 'column',
         '&:hover': {
           boxShadow: 'md',
-          transform: 'translateY(-2px)'
-        }
+          transform: 'translateY(-2px)',
+        },
       }}
-      onClick={onClick}
     >
-      <CardContent>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
-          <Typography level="title-md" sx={{ fontWeight: 'bold' }}>
-            {meeting.meeting_name}
-          </Typography>
-          <Chip 
-            variant="soft" 
+      <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {/* Header with portfolio and date */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+          <Chip
             color={getPortfolioColor(portfolioName)}
             size="sm"
+            variant="soft"
+            sx={{ flexShrink: 0 }}
           >
             {portfolioName}
           </Chip>
+          <Typography level="body-sm" color="neutral" sx={{ flexShrink: 0 }}>
+            {formatDate(meeting.meeting_date)}
+          </Typography>
         </Box>
-        
-        <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
-          {formatDate(meeting.meeting_date)}
+
+        {/* Meeting title */}
+        <Typography 
+          level="title-md" 
+          sx={{ 
+            fontWeight: 'bold',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            lineHeight: 1.4,
+            minHeight: '2.8em', // Reserve space for 2 lines
+          }}
+        >
+          {meeting.meeting_name}
         </Typography>
-        
-        {meeting.summary && (
+
+        {/* Summary */}
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <Typography 
             level="body-sm" 
+            color="neutral"
             sx={{ 
               display: '-webkit-box',
-              WebkitLineClamp: 3,
+              WebkitLineClamp: 4,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
-              lineHeight: 1.4
+              lineHeight: 1.5,
+              flex: 1,
             }}
           >
-            {meeting.summary}
+            {meeting.summary || 'No summary available'}
           </Typography>
-        )}
-        
-        <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+        </Box>
+
+        {/* Status indicators */}
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 'auto' }}>
           {meeting.has_recording && (
-            <Chip variant="soft" color="success" size="sm">
+            <Chip size="sm" color="success" variant="soft">
               Recording
             </Chip>
           )}
           {meeting.has_summary && (
-            <Chip variant="soft" color="primary" size="sm">
+            <Chip size="sm" color="primary" variant="soft">
               Summary
             </Chip>
           )}

--- a/frontend/src/components/joyui/meeting/MeetingDetailClient.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingDetailClient.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { MeetingRecordDetailResponse, PortfolioListResponse, TaskListResponse } from "@/lib/types";
+import { ArrowBack } from "@mui/icons-material";
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    Grid,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemContent,
+    Typography
+} from "@mui/joy";
+import { useRouter } from "next/navigation";
+
+interface MeetingDetailClientProps {
+  meeting: MeetingRecordDetailResponse;
+  relatedTasks: TaskListResponse[];
+  portfolios: PortfolioListResponse[];
+}
+
+export default function MeetingDetailClient({ 
+  meeting, 
+  relatedTasks, 
+  portfolios 
+}: MeetingDetailClientProps) {
+  const router = useRouter();
+
+  // Create a portfolio lookup map for efficient name resolution
+  const portfolioMap = portfolios.reduce((map, portfolio) => {
+    map[portfolio.portfolio_id] = portfolio.name;
+    return map;
+  }, {} as Record<number, string>);
+
+  const portfolioName = portfolioMap[meeting.portfolio_id] || "Unknown";
+
+  const formatDate = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    } catch (error) {
+      return dateString;
+    }
+  };
+
+  const getPortfolioColor = (portfolio: string) => {
+    switch (portfolio.toLowerCase()) {
+      case 'product':
+        return 'primary';
+      case 'marketing':
+        return 'success';
+      case 'finance':
+        return 'warning';
+      default:
+        return 'neutral';
+    }
+  };
+
+  const handleTaskClick = (taskId: number) => {
+    router.push(`/taskbot/tasks/${taskId}`);
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
+        <Button
+          variant="plain"
+          startDecorator={<ArrowBack />}
+          onClick={() => router.back()}
+          sx={{ mr: 2 }}
+        >
+          Back
+        </Button>
+        <Box sx={{ flexGrow: 1 }}>
+          <Typography level="h1" sx={{ mb: 1 }}>
+            {meeting.meeting_name}
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Chip 
+              variant="soft" 
+              color={getPortfolioColor(portfolioName)}
+              size="sm"
+            >
+              {portfolioName}
+            </Chip>
+            <Typography level="body-sm" color="neutral">
+              {formatDate(meeting.meeting_date)}
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Main Content */}
+      <Grid container spacing={3}>
+        {/* Left Column - Transcript */}
+        <Grid xs={12} md={8}>
+          <Card variant="outlined" sx={{ height: 'fit-content' }}>
+            <CardContent>
+              <Typography level="title-lg" sx={{ mb: 2 }}>
+                Transcript
+              </Typography>
+              {meeting.auto_caption ? (
+                <Typography 
+                  level="body-sm" 
+                  sx={{ 
+                    whiteSpace: 'pre-wrap',
+                    lineHeight: 1.6,
+                    maxHeight: '60vh',
+                    overflow: 'auto',
+                    p: 2,
+                    backgroundColor: 'background.level1',
+                    borderRadius: 'sm'
+                  }}
+                >
+                  {meeting.auto_caption}
+                </Typography>
+              ) : (
+                <Typography level="body-sm" color="neutral" sx={{ fontStyle: 'italic' }}>
+                  No transcript available for this meeting.
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Right Column - Summary and Related Tasks */}
+        <Grid xs={12} md={4}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {/* Meeting Summary */}
+            <Card variant="outlined">
+              <CardContent>
+                <Typography level="title-lg" sx={{ mb: 2 }}>
+                  Meeting Summary
+                </Typography>
+                {meeting.summary ? (
+                  <Typography 
+                    level="body-sm" 
+                    sx={{ 
+                      whiteSpace: 'pre-wrap',
+                      lineHeight: 1.6 
+                    }}
+                  >
+                    {meeting.summary}
+                  </Typography>
+                ) : (
+                  <Typography level="body-sm" color="neutral" sx={{ fontStyle: 'italic' }}>
+                    No summary available for this meeting.
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Related Tasks */}
+            <Card variant="outlined">
+              <CardContent>
+                <Typography level="title-lg" sx={{ mb: 2 }}>
+                  Related Tasks
+                </Typography>
+                {relatedTasks.length > 0 ? (
+                  <List size="sm">
+                    {relatedTasks.map((task) => (
+                      <ListItem key={task.task_id}>
+                        <ListItemButton
+                          onClick={() => handleTaskClick(task.task_id)}
+                          sx={{ 
+                            borderRadius: 'sm',
+                            '&:hover': {
+                              backgroundColor: 'background.level2'
+                            }
+                          }}
+                        >
+                          <ListItemContent>
+                            <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
+                              {task.title}
+                            </Typography>
+                            {task.description && (
+                              <Typography 
+                                level="body-xs" 
+                                color="neutral"
+                                sx={{ 
+                                  mt: 0.5,
+                                  display: '-webkit-box',
+                                  WebkitLineClamp: 2,
+                                  WebkitBoxOrient: 'vertical',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis'
+                                }}
+                              >
+                                {task.description}
+                              </Typography>
+                            )}
+                          </ListItemContent>
+                        </ListItemButton>
+                      </ListItem>
+                    ))}
+                  </List>
+                ) : (
+                  <Typography level="body-sm" color="neutral" sx={{ fontStyle: 'italic' }}>
+                    No related tasks found for this meeting.
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+} 

--- a/frontend/src/components/joyui/meeting/MeetingDetailClient.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingDetailClient.tsx
@@ -3,17 +3,16 @@
 import { MeetingRecordDetailResponse, PortfolioListResponse, TaskListResponse } from "@/lib/types";
 import { ArrowBack } from "@mui/icons-material";
 import {
-    Box,
-    Button,
-    Card,
-    CardContent,
-    Chip,
-    Grid,
-    List,
-    ListItem,
-    ListItemButton,
-    ListItemContent,
-    Typography
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  List,
+  ListItem,
+  ListItemContent,
+  Typography
 } from "@mui/joy";
 import { useRouter } from "next/navigation";
 
@@ -57,8 +56,19 @@ export default function MeetingDetailClient({
     return 'primary' as const;
   };
 
-  const handleTaskClick = (taskId: number) => {
-    router.push(`/taskbot/tasks/${taskId}`);
+  const getTaskStatusColor = (status: string) => {
+    switch (status?.toLowerCase()) {
+      case 'completed':
+        return 'success' as const;
+      case 'in progress':
+        return 'warning' as const;
+      case 'cancelled':
+        return 'danger' as const;
+      case 'pending':
+        return 'neutral' as const;
+      default:
+        return 'neutral' as const;
+    }
   };
 
   return (
@@ -161,38 +171,48 @@ export default function MeetingDetailClient({
                 {relatedTasks.length > 0 ? (
                   <List size="sm">
                     {relatedTasks.map((task) => (
-                      <ListItem key={task.task_id}>
-                        <ListItemButton
-                          onClick={() => handleTaskClick(task.task_id)}
-                          sx={{ 
-                            borderRadius: 'sm',
-                            '&:hover': {
-                              backgroundColor: 'background.level2'
-                            }
-                          }}
-                        >
-                          <ListItemContent>
-                            <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
+                      <ListItem 
+                        key={task.task_id}
+                        sx={{ 
+                          borderRadius: 'sm',
+                          p: 1,
+                          border: '1px solid',
+                          borderColor: 'divider',
+                          mb: 1
+                        }}
+                      >
+                        <ListItemContent>
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}>
+                            <Typography level="body-sm" sx={{ fontWeight: 'md', flex: 1 }}>
                               {task.title}
                             </Typography>
-                            {task.description && (
-                              <Typography 
-                                level="body-xs" 
-                                color="neutral"
-                                sx={{ 
-                                  mt: 0.5,
-                                  display: '-webkit-box',
-                                  WebkitLineClamp: 2,
-                                  WebkitBoxOrient: 'vertical',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis'
-                                }}
+                            {task.status && (
+                              <Chip 
+                                size="sm" 
+                                color={getTaskStatusColor(task.status)}
+                                variant="soft"
+                                sx={{ ml: 1, flexShrink: 0 }}
                               >
-                                {task.description}
-                              </Typography>
+                                {task.status}
+                              </Chip>
                             )}
-                          </ListItemContent>
-                        </ListItemButton>
+                          </Box>
+                          {task.description && (
+                            <Typography 
+                              level="body-xs" 
+                              color="neutral"
+                              sx={{ 
+                                display: '-webkit-box',
+                                WebkitLineClamp: 2,
+                                WebkitBoxOrient: 'vertical',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis'
+                              }}
+                            >
+                              {task.description}
+                            </Typography>
+                          )}
+                        </ListItemContent>
                       </ListItem>
                     ))}
                   </List>

--- a/frontend/src/components/joyui/meeting/MeetingDetailClient.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingDetailClient.tsx
@@ -54,16 +54,7 @@ export default function MeetingDetailClient({
   };
 
   const getPortfolioColor = (portfolio: string) => {
-    switch (portfolio.toLowerCase()) {
-      case 'product':
-        return 'primary';
-      case 'marketing':
-        return 'success';
-      case 'finance':
-        return 'warning';
-      default:
-        return 'neutral';
-    }
+    return 'primary' as const;
   };
 
   const handleTaskClick = (taskId: number) => {

--- a/frontend/src/components/joyui/meeting/MeetingListClient.tsx
+++ b/frontend/src/components/joyui/meeting/MeetingListClient.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import MeetingCard from "@/components/joyui/meeting/MeetingCard";
+import { MeetingRecordListResponse, PortfolioListResponse } from "@/lib/types";
+import { Box, Grid, Typography } from "@mui/joy";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface MeetingListClientProps {
+  initialMeetings: MeetingRecordListResponse[];
+  portfolios: PortfolioListResponse[];
+}
+
+export default function MeetingListClient({ 
+  initialMeetings, 
+  portfolios 
+}: MeetingListClientProps) {
+  const [meetings] = useState(initialMeetings);
+  const router = useRouter();
+
+  // Create a portfolio lookup map for efficient name resolution
+  const portfolioMap = portfolios.reduce((map, portfolio) => {
+    map[portfolio.portfolio_id] = portfolio.name;
+    return map;
+  }, {} as Record<number, string>);
+
+  const handleMeetingClick = (meetingId: number) => {
+    router.push(`/taskbot/meetings/${meetingId}`);
+  };
+
+  if (meetings.length === 0) {
+    return (
+      <Box sx={{ textAlign: "center", py: 8 }}>
+        <Typography level="h3" color="neutral">
+          No meetings found
+        </Typography>
+        <Typography color="neutral" sx={{ mt: 1 }}>
+          There are no meetings to display at this time.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Grid container spacing={3}>
+      {meetings.map((meeting) => (
+        <Grid key={meeting.meeting_id} xs={12} sm={6} md={4}>
+          <MeetingCard
+            meeting={meeting}
+            portfolioName={portfolioMap[meeting.portfolio_id] || "Unknown"}
+            onClick={() => handleMeetingClick(meeting.meeting_id)}
+          />
+        </Grid>
+      ))}
+    </Grid>
+  );
+} 

--- a/frontend/src/lib/api/meetingRecord.ts
+++ b/frontend/src/lib/api/meetingRecord.ts
@@ -1,0 +1,66 @@
+import { MeetingRecordDetailResponse, MeetingRecordListResponse, TaskListResponse } from "../types";
+import { apiFetch } from "./client";
+
+/**
+ * Get all meeting records with optional filters
+ */
+export async function getMeetingRecords(
+  portfolioId?: number,
+  startDate?: string,
+  endDate?: string,
+  hasRecording?: boolean,
+  hasSummary?: boolean,
+  skip: number = 0,
+  limit: number = 100
+): Promise<MeetingRecordListResponse[]> {
+  const params = new URLSearchParams();
+  
+  if (portfolioId) params.append('portfolio_id', portfolioId.toString());
+  if (startDate) params.append('start_date', startDate);
+  if (endDate) params.append('end_date', endDate);
+  if (hasRecording !== undefined) params.append('has_recording', hasRecording.toString());
+  if (hasSummary !== undefined) params.append('has_summary', hasSummary.toString());
+  params.append('skip', skip.toString());
+  params.append('limit', limit.toString());
+
+  const queryString = params.toString();
+  const endpoint = queryString ? `/api/v1/meeting-records/?${queryString}` : '/api/v1/meeting-records/';
+  
+  return await apiFetch(endpoint, {
+    method: "GET",
+  });
+}
+
+/**
+ * Get meeting record details by ID
+ */
+export async function getMeetingRecordById(meetingId: number): Promise<MeetingRecordDetailResponse> {
+  return await apiFetch(`/api/v1/meeting-records/${meetingId}`, {
+    method: "GET",
+  });
+}
+
+/**
+ * Get tasks related to a specific meeting
+ */
+export async function getTasksByMeeting(meetingId: number): Promise<TaskListResponse[]> {
+  return await apiFetch(`/api/v1/tasks/meeting/${meetingId}`, {
+    method: "GET",
+  });
+}
+
+/**
+ * Search meeting records by query
+ */
+export async function searchMeetingRecords(
+  query: string,
+  portfolioId?: number
+): Promise<MeetingRecordListResponse[]> {
+  const params = new URLSearchParams();
+  params.append('q', query);
+  if (portfolioId) params.append('portfolio_id', portfolioId.toString());
+
+  return await apiFetch(`/api/v1/meeting-records/search/?${params.toString()}`, {
+    method: "GET",
+  });
+} 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -49,6 +49,47 @@ export interface TaskFormData {
   portfolio_id: number;
 }
 
+// Meeting Record types based on OpenAPI spec
+export interface MeetingRecordListResponse {
+  meeting_id: number;
+  meeting_date: string;
+  meeting_name: string;
+  portfolio_id: number;
+  user_can_see: boolean;
+  has_recording: boolean;
+  has_summary: boolean;
+  summary?: string;
+  portfolio_name?: string;
+}
+
+export interface MeetingRecordDetailResponse {
+  meeting_date: string;
+  meeting_name: string;
+  recording_file_link?: string;
+  auto_caption?: string;
+  summary?: string;
+  portfolio_id: number;
+  user_can_see: boolean;
+  meeting_id: number;
+  portfolio_name?: string;
+  related_tasks_count?: number;
+}
+
+export interface TaskListResponse {
+  task_id: number;
+  title: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  deadline: string;
+  parent_task_id?: number;
+  source_meeting_id?: number;
+  portfolio_id: number;
+  created_at?: string;
+  updated_at?: string;
+  created_by: number;
+}
+
 // Meeting related types
 export interface Meeting {
   id: string;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,10 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 import { RoleName, User } from "./types";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
 
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString);


### PR DESCRIPTION
This pull request introduces a new `user_can_see` field in the `MeetingRecord` model and implements permission-based filtering for meeting records across the API. The changes ensure that users can only access meeting records they are authorized to view, based on their role and portfolio association. Additionally, the `portfolio_name` field is now included in API responses for better context.

### Database Schema Updates:
* Added `user_can_see` column to the `meeting_records` table to control visibility of records for regular users.
* Updated the `MeetingRecord` model to include the `user_can_see` field with a default value of `True`.

### API Enhancements:
* Introduced permission-based filtering in the following endpoints:
  - [`read_meeting_record`](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL41-R48): Uses `get_by_id_with_permissions` to enforce access control.
  - [`read_meeting_records`](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL68-R78): Replaced `get_multi` with `get_multi_with_permissions` for permission checks.
  - Other endpoints like `update_meeting_record`, `delete_meeting_record`, and those fetching meeting records by portfolio, recordings, summaries, or search terms now include similar permission checks. [[1]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL101-R121) [[2]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL119-R138) [[3]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL138-R171) [[4]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL163-R201) [[5]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL186-R231) [[6]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL209-R260)

### CRUD Layer Updates:
* Added `get_multi_with_permissions` and `get_by_id_with_permissions` methods to apply role-based and portfolio-based filtering logic in database queries. (F604c62aL83R186)
* Updated existing methods like `get_by_id`, `get_by_portfolio`, and others to preload the `portfolio` relationship using `joinedload`, ensuring `portfolio_name` is available in API responses. [[1]](diffhunk://#diff-9fe8bbae80be28468cb2d33a35ab1addf11ec17c01b67bb272f1603afa8e0d14L2-R24) [[2]](diffhunk://#diff-9fe8bbae80be28468cb2d33a35ab1addf11ec17c01b67bb272f1603afa8e0d14L32-R41) [[3]](diffhunk://#diff-9fe8bbae80be28468cb2d33a35ab1addf11ec17c01b67bb272f1603afa8e0d14L56-R58)

### Response Improvements:
* Included `portfolio_name` in API responses for meeting records, enhancing the context provided to clients. This change affects multiple endpoints such as `create_meeting_record`, `read_meeting_records`, and others. [[1]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dL30-R35) [[2]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dR57) [[3]](diffhunk://#diff-fffa3cd55254695d5d78a9824be5ebb851dc74c48333b347b669a18975d19d7dR94)