### PR TITLE
Refactor task assignment and task retrieval endpoints to use TaskListResponse schema

### DIFF
--- a/backend/app/api/api_v1/endpoints/tasks.py
+++ b/backend/app/api/api_v1/endpoints/tasks.py
@@ -31,7 +31,7 @@ def create_task(
     Create new task
     """
     task_record = task.create_task(db, obj_in=task_in, created_by=current_user.user_id)
-    return TaskResponse(**task_record.__dict__)
+    return task_record
 
 
 @router.get("/", response_model=list[TaskListResponse])
@@ -126,12 +126,11 @@ def update_task(
     """
     Update task
     """
-    task_record = task.get_by_id(db, task_id=task_id)
-    if not task_record:
+    task_obj = task.get_by_id(db, task_id=task_id)
+    if not task_obj:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    task_record = task.update_task(db, db_obj=task_record, obj_in=task_in)
-    return TaskResponse(**task_record.__dict__)
+    return task.update_task(db, db_obj=task_obj, obj_in=task_in)
 
 
 @router.delete("/{task_id}")

--- a/backend/app/api/api_v1/endpoints/tasks.py
+++ b/backend/app/api/api_v1/endpoints/tasks.py
@@ -43,14 +43,21 @@ def read_tasks(
     skip: int = Query(0, ge=0, description="Skip items"),
     limit: int = Query(100, ge=1, le=1000, description="Limit items"),
     current_user: User = Depends(deps.get_current_user),
+    include_subtasks: bool = Query(True, description="Include subtasks in response"),
 ) -> list[TaskListResponse]:
     """
     Get tasks with optional filters
     """
-    tasks = task.get_multi(
-        db, portfolio_id=portfolio_id, status=status, priority=priority, skip=skip, limit=limit
+    tasks_data = task.get_multi(
+        db,
+        portfolio_id=portfolio_id,
+        status=status,
+        priority=priority,
+        skip=skip,
+        limit=limit,
+        include_subtasks=include_subtasks,
     )
-    return [TaskListResponse(**task_record.__dict__) for task_record in tasks]
+    return [TaskListResponse(**task_data) for task_data in tasks_data]
 
 
 @router.get("/created-by/{user_id}", response_model=list[TaskListResponse])
@@ -66,7 +73,7 @@ def read_tasks_created_by(
     Get tasks created by a specific user
     """
     tasks = task.get_by_created_by(db, user_id=user_id, skip=skip, limit=limit)
-    return [TaskListResponse(**task_record.__dict__) for task_record in tasks]
+    return [TaskListResponse(**task_data) for task_data in tasks]
 
 
 @router.get("/{task_id}/created-by", response_model=TaskCreatedByResponse)
@@ -101,7 +108,7 @@ def read_task(
 
     # Get subtasks if any
     subtasks = task.get_subtasks(db, parent_task_id=task_id)
-    subtasks_data = [TaskListResponse(**subtask.__dict__) for subtask in subtasks]
+    subtasks_data = [TaskListResponse(**subtask_data) for subtask_data in subtasks]
 
     task_data = TaskDetailResponse(**task_record.__dict__)
     task_data.subtasks = subtasks_data
@@ -157,7 +164,7 @@ def read_tasks_by_portfolio(
     Get tasks by portfolio ID
     """
     tasks = task.get_by_portfolio(db, portfolio_id=portfolio_id, skip=skip, limit=limit)
-    return [TaskListResponse(**task_record.__dict__) for task_record in tasks]
+    return [TaskListResponse(**task_data) for task_data in tasks]
 
 
 @router.get("/subtasks/{parent_task_id}", response_model=list[TaskListResponse])
@@ -171,7 +178,7 @@ def read_subtasks(
     Get subtasks of a parent task
     """
     subtasks = task.get_subtasks(db, parent_task_id=parent_task_id)
-    return [TaskListResponse(**subtask.__dict__) for subtask in subtasks]
+    return [TaskListResponse(**subtask_data) for subtask_data in subtasks]
 
 
 @router.get("/meeting/{meeting_id}", response_model=list[TaskListResponse])
@@ -185,7 +192,7 @@ def read_tasks_by_meeting(
     Get tasks created from a specific meeting
     """
     tasks = task.get_by_meeting(db, meeting_id=meeting_id)
-    return [TaskListResponse(**task_record.__dict__) for task_record in tasks]
+    return [TaskListResponse(**task_data) for task_data in tasks]
 
 
 @router.get("/meeting/{meeting_id}/pending", response_model=list[TaskListResponse])
@@ -199,7 +206,7 @@ def get_pending_tasks_by_meeting(
     Get pending tasks created from a specific meeting
     """
     tasks = task.get_pending_tasks_by_meeting(db, meeting_id=meeting_id)
-    return [TaskListResponse(**task_record.__dict__) for task_record in tasks]
+    return [TaskListResponse(**task_data) for task_data in tasks]
 
 
 @router.get("/search/", response_model=list[TaskListResponse])
@@ -214,7 +221,7 @@ def search_tasks(
     Search tasks by title or description
     """
     tasks = task.search_tasks(db, search_term=q, portfolio_id=portfolio_id)
-    return [TaskListResponse(**task_record.__dict__) for task_record in tasks]
+    return [TaskListResponse(**task_data) for task_data in tasks]
 
 
 @router.get("/reminders/tomorrow", response_model=TomorrowRemindersResponse)

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database.session import Base
 
 if TYPE_CHECKING:
+    from app.models.task_assignment import TaskAssignment
     from app.models.meeting_record import MeetingRecord
     from app.models.portfolio import Portfolio
     from app.models.user import User
@@ -46,3 +47,6 @@ class Task(Base):
         "MeetingRecord", back_populates="tasks"
     )
     created_by_user: Mapped["User"] = relationship("User", back_populates="created_tasks")
+    task_assignments: Mapped[list["TaskAssignment"]] = relationship(
+        "TaskAssignment", back_populates="task"
+    )

--- a/backend/app/models/task_assignment.py
+++ b/backend/app/models/task_assignment.py
@@ -1,11 +1,14 @@
 from typing import TYPE_CHECKING
-from sqlalchemy import ForeignKey, Integer
+
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
 from app.database.session import Base
 
 if TYPE_CHECKING:
     from app.models.task import Task
     from app.models.user import User
+
 
 class TaskAssignment(Base):
     __tablename__ = "task_assignments"
@@ -15,5 +18,5 @@ class TaskAssignment(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.user_id"), nullable=False)
 
     # Relationships
-    task: Mapped["Task"] = relationship("Task")
-    user: Mapped["User"] = relationship("User") 
+    task: Mapped["Task"] = relationship("Task", back_populates="task_assignments")
+    user: Mapped["User"] = relationship("User")

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -5,26 +5,19 @@ from pydantic import BaseModel, computed_field
 from app.schemas.task_assignment import TaskUserAssignmentResponse
 
 
-# Shared properties
-class TaskBase(BaseModel):
+class TaskPortfolioResponse(BaseModel):
+    portfolio_id: int
+    name: str
+
+
+class TaskCreateRequestBody(BaseModel):
     title: str
     description: str | None = None
-    status: str | None = "Not Started"
     priority: str | None = "Medium"
     deadline: datetime
     portfolio_id: int
-    parent_task_id: int | None = None
-    source_meeting_id: int | None = None
 
 
-# Used when creating a task
-class TaskCreateRequestBody(TaskBase):
-    title: str
-    deadline: datetime
-    portfolio_id: int
-
-
-# Used when updating a task
 class TaskUpdate(BaseModel):
     title: str | None = None
     description: str | None = None
@@ -36,17 +29,6 @@ class TaskUpdate(BaseModel):
     source_meeting_id: int | None = None
 
 
-# Used for API responses
-class TaskResponse(TaskBase):
-    task_id: int
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-    created_by: int
-
-    class Config:
-        from_attributes = True
-
-
 class TaskCreatedByResponse(BaseModel):
     user_id: int
     username: str
@@ -56,12 +38,25 @@ class TaskCreatedByResponse(BaseModel):
         from_attributes = True
 
 
-class TaskPortfolioResponse(BaseModel):
-    portfolio_id: int
-    name: str
+class TaskResponse(BaseModel):
+    task_id: int
+    title: str
+    description: str | None = None
+    status: str | None = None
+    priority: str | None = None
+    deadline: datetime
+    parent_task_id: int | None = None
+    source_meeting_id: int | None = None
+    portfolio: TaskPortfolioResponse
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    created_by: TaskCreatedByResponse
+    assignees: list[TaskUserAssignmentResponse] | None = None
+
+    class Config:
+        from_attributes = True
 
 
-# Used for listing tasks (minimal info)
 class TaskListResponse(BaseModel):
     task_id: int
     title: str

--- a/backend/app/schemas/task_assignment.py
+++ b/backend/app/schemas/task_assignment.py
@@ -33,8 +33,8 @@ class TaskAssignmentResponse(TaskAssignmentBase):
 class TaskAssignmentDetailResponse(TaskAssignmentResponse):
     # Optional fields for related data
     task_title: str | None = None
-    user_username: str | None = None
-    user_email: str | None = None
+    username: str | None = None
+    email: str | None = None
 
     class Config:
         from_attributes = True
@@ -69,8 +69,8 @@ class UserTaskAssignmentResponse(BaseModel):
 class TaskUserAssignmentResponse(BaseModel):
     assignment_id: int
     user_id: int
-    user_username: str
-    user_email: str
+    username: str
+    email: str
 
     class Config:
         from_attributes = True

--- a/frontend/src/app/(internal)/taskbot/dashboard/page.tsx
+++ b/frontend/src/app/(internal)/taskbot/dashboard/page.tsx
@@ -1,13 +1,12 @@
 import {
   fetchUserTasks,
-  transformUserTaskToTask,
   updateTaskStatus,
   updateTask,
   updateTaskAssignment,
   createTask,
 } from "@/lib/api/task";
 import { searchUsers } from "@/lib/api/user";
-import { Task, TaskCreateRequest, TaskStatus, User } from "@/lib/types";
+import { TaskCreateRequest, TaskResponse, TaskStatus, User } from "@/lib/types";
 import { revalidatePath } from "next/cache";
 import { Suspense } from "react";
 import TaskLoadingState from "@/components/joyui/task/TaskLoadingState";
@@ -31,11 +30,11 @@ async function updateTaskStatusAction(taskId: number, status: TaskStatus) {
   }
 }
 
-async function updateTaskAction(taskId: number, updates: Partial<Task>) {
+async function updateTaskAction(taskId: number, updates: Partial<TaskResponse>) {
   "use server";
 
   try {
-    await updateTask(taskId, updates);
+    await updateTask(taskId, updates as Partial<TaskResponse>);
     revalidatePath("/taskbot/dashboard");
     return { success: true };
   } catch (error) {
@@ -96,12 +95,11 @@ async function createTaskAction(taskData: TaskCreateRequest) {
 async function TaskData() {
   try {
     const tasks = await fetchUserTasks();
-    const transformedTasks = await Promise.all(tasks.map(transformUserTaskToTask));
     const portfolios = await getAllPortfoliosSimple();
 
     return (
       <TaskDashboardClient
-        tasks={transformedTasks}
+        tasks={tasks as TaskResponse[]}
         updateTaskStatusAction={updateTaskStatusAction}
         updateTaskAction={updateTaskAction}
         createTaskAction={createTaskAction}

--- a/frontend/src/app/(internal)/taskbot/layout.tsx
+++ b/frontend/src/app/(internal)/taskbot/layout.tsx
@@ -1,6 +1,8 @@
 import TaskbotLayoutClient from "@/components/joyui/task/TaskbotLayoutClient";
 import { UserProvider } from "@/components/providers/UserProvider";
 import { getCurrentUser } from "@/lib/session";
+import { CssVarsProvider } from "@mui/joy/styles";
+import CssBaseline from "@mui/joy/CssBaseline";
 
 export default async function TaskbotLayout({ children }: { children: React.ReactNode }) {
   const userResponse = await getCurrentUser().catch(() => null);
@@ -15,8 +17,11 @@ export default async function TaskbotLayout({ children }: { children: React.Reac
   } : undefined;
 
   return (
-    <UserProvider initialUser={user || undefined}>
-      <TaskbotLayoutClient>{children}</TaskbotLayoutClient>
-    </UserProvider>
+    <CssVarsProvider disableTransitionOnChange>
+      <CssBaseline />
+      <UserProvider initialUser={user || undefined}>
+        <TaskbotLayoutClient>{children}</TaskbotLayoutClient>
+      </UserProvider>
+    </CssVarsProvider>
   );
 }

--- a/frontend/src/components/joyui/task/TaskCard.tsx
+++ b/frontend/src/components/joyui/task/TaskCard.tsx
@@ -14,7 +14,7 @@ import Divider from "@mui/joy/Divider";
 import IconButton from "@mui/joy/IconButton";
 import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
 import EditIcon from "@mui/icons-material/Edit";
-import { Task, TaskStatus, User } from "@/lib/types";
+import { TaskResponse, TaskStatus, User } from "@/lib/types";
 import { formatDateWithMinutes } from "@/lib/utils";
 import Modal from "@mui/joy/Modal";
 import ModalDialog from "@mui/joy/ModalDialog";
@@ -59,12 +59,12 @@ const statusOptions: TaskStatus[] = ["Not Started", "In Progress", "Completed", 
 
 // Task Card Component Props
 interface TaskCardProps {
-  task: Task;
-  onStatusUpdate: (task: Task, newStatus: TaskStatus) => void;
+  task: TaskResponse;
+  onStatusUpdate: (task: TaskResponse, newStatus: TaskStatus) => void;
   isUpdating?: boolean;
   updateTaskAction?: (
     taskId: number,
-    updates: Partial<Task>
+    updates: Partial<TaskResponse>
   ) => Promise<{ success: boolean; error?: string }>;
   searchUsersAction?: (searchTerm: string) => Promise<User[]>;
   updateTaskAssignmentAction?: (
@@ -86,7 +86,7 @@ export default function TaskCard({
   // Add a mounted state to prevent hydration issues
   const [mounted, setMounted] = React.useState(false);
   const [showDetails, setShowDetails] = React.useState(false);
-  const [expandedSubtask, setExpandedSubtask] = React.useState<Task | null>(null);
+  const [expandedSubtask, setExpandedSubtask] = React.useState<TaskResponse | null>(null);
   const [editModalOpen, setEditModalOpen] = React.useState(false);
   const [isUpdatingTask, setIsUpdatingTask] = React.useState(false);
 
@@ -108,10 +108,10 @@ export default function TaskCard({
   };
 
   // Handle save task changes
-  const handleSaveTask = async (updates: Partial<Task>) => {
+  const handleSaveTask = async (updates: Partial<TaskResponse>) => {
     setIsUpdatingTask(true);
     try {
-      const result = await updateTaskAction?.(task.id, updates);
+      const result = await updateTaskAction?.(task.task_id, updates);
       if (result?.success) {
         setEditModalOpen(false);
       } else {
@@ -157,7 +157,7 @@ export default function TaskCard({
                 {task.title}
               </Typography>
               <Typography level="body-sm" color="neutral" sx={{ mt: 0.5 }}>
-                {task.portfolio}
+                {task.portfolio.name}
               </Typography>
             </Box>
             <Stack direction="row" spacing={1} sx={{ alignItems: "flex-start" }}>
@@ -267,7 +267,7 @@ export default function TaskCard({
                       <Stack spacing={1}>
                         {task.subtasks.map(subtask => (
                           <Box
-                            key={subtask.id}
+                            key={subtask.task_id}
                             onClick={() => setExpandedSubtask(subtask)}
                             sx={{
                               p: 1.5,
@@ -297,7 +297,7 @@ export default function TaskCard({
                                 overflow: "hidden",
                               }}
                             >
-                              <Chip size="sm" variant="soft" color={getStatusColor(subtask.status)}>
+                              <Chip size="sm" variant="soft" color={getStatusColor(subtask.status as TaskStatus)}>
                                 {subtask.status}
                               </Chip>
                               <Typography
@@ -380,10 +380,9 @@ export default function TaskCard({
             <AvatarsList
               label="Assigned to:"
               users={(task.assignees || []).map(assignee => ({
-                id: assignee.id,
-                name: assignee.name,
+                id: assignee.user_id,
+                name: assignee.username,
                 email: assignee.email,
-                avatar: assignee.avatar,
               }))}
               showGroup={true}
             />
@@ -411,7 +410,7 @@ export default function TaskCard({
 
       <CardActions sx={{ pt: 0 }}>
         <Stack direction="row" spacing={1} sx={{ width: "100%", alignItems: "center" }}>
-          <Chip variant="soft" color={getStatusColor(task.status)} size="sm">
+          <Chip variant="soft" color={getStatusColor(task.status as TaskStatus)} size="sm">
             {task.status}
           </Chip>
           <Box sx={{ flex: 1 }} />
@@ -423,7 +422,7 @@ export default function TaskCard({
               }
             }}
             size="sm"
-            color={getStatusColor(task.status)}
+            color={getStatusColor(task.status as TaskStatus)}
             variant="outlined"
             disabled={isUpdating}
             sx={{
@@ -434,7 +433,7 @@ export default function TaskCard({
           >
             {statusOptions.map(status => (
               <Option key={status} value={status}>
-                <Chip size="sm" variant="soft" color={getStatusColor(status)} sx={{ mr: 1 }}>
+                <Chip size="sm" variant="soft" color={getStatusColor(status as TaskStatus)} sx={{ mr: 1 }}>
                   {status}
                 </Chip>
               </Option>

--- a/frontend/src/components/joyui/task/TaskDashboardClient.tsx
+++ b/frontend/src/components/joyui/task/TaskDashboardClient.tsx
@@ -5,17 +5,17 @@ import AddIcon from "@mui/icons-material/Add";
 import Tasks from "@/components/joyui/task/Tasks";
 import TaskFormModal from "./TaskFormModal";
 import {
-  Task,
   TaskStatus,
   User,
   TaskFormData,
   TaskCreateRequest,
   PortfolioSimple,
+  TaskResponse,
 } from "@/lib/types";
 import React, { useState, useEffect, useTransition } from "react";
 
 interface TaskDashboardClientProps {
-  tasks: Task[];
+  tasks: TaskResponse[];
   error?: string;
   updateTaskStatusAction?: (
     taskId: number,
@@ -23,7 +23,7 @@ interface TaskDashboardClientProps {
   ) => Promise<{ success: boolean; error?: string }>;
   updateTaskAction?: (
     taskId: number,
-    updates: Partial<Task>
+    updates: Partial<TaskResponse>
   ) => Promise<{ success: boolean; error?: string }>;
   searchUsersAction?: (searchTerm: string) => Promise<User[]>;
   updateTaskAssignmentAction?: (

--- a/frontend/src/components/joyui/task/TaskbotLayoutClient.tsx
+++ b/frontend/src/components/joyui/task/TaskbotLayoutClient.tsx
@@ -2,8 +2,6 @@
 
 import React from "react";
 import Box from "@mui/joy/Box";
-import { CssVarsProvider } from "@mui/joy/styles";
-import CssBaseline from "@mui/joy/CssBaseline";
 import IconButton from "@mui/joy/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
 import Sidebar from "@/components/joyui/Sidebar";
@@ -12,11 +10,8 @@ import { openSidebar } from "@/lib/dom-utils";
 interface TaskbotLayoutClientProps {
   children: React.ReactNode;
 }
-
 export default function TaskbotLayoutClient({ children }: TaskbotLayoutClientProps) {
-  return (
-    <CssVarsProvider disableTransitionOnChange>
-      <CssBaseline />
+    return (
       <Box sx={{ display: "flex", minHeight: "100vh" }}>
         <Sidebar />
         <Box
@@ -60,10 +55,9 @@ export default function TaskbotLayoutClient({ children }: TaskbotLayoutClientPro
           >
             <MenuIcon />
           </IconButton>
-
+  
           {children}
         </Box>
       </Box>
-    </CssVarsProvider>
-  );
-}
+    );
+  }

--- a/frontend/src/components/joyui/task/Tasks.tsx
+++ b/frontend/src/components/joyui/task/Tasks.tsx
@@ -6,7 +6,7 @@ import Card from "@mui/joy/Card";
 import CardContent from "@mui/joy/CardContent";
 import Typography from "@mui/joy/Typography";
 import Stack from "@mui/joy/Stack";
-import { Task, TaskStatus, User } from "@/lib/types";
+import { TaskResponse, TaskStatus, User } from "@/lib/types";
 import TaskCard from "./TaskCard";
 import { Tab, TabList, Tabs } from "@mui/joy";
 
@@ -14,12 +14,12 @@ interface TasksProps {
   myTasks?: boolean;
   directorPortfolioId?: number;
   admin?: boolean;
-  tasks: Task[];
+  tasks: TaskResponse[];
   onTaskStatusUpdate?: (taskId: number, status: TaskStatus) => Promise<void>;
   isUpdating?: boolean;
   updateTaskAction?: (
     taskId: number,
-    updates: Partial<Task>
+    updates: Partial<TaskResponse>
   ) => Promise<{ success: boolean; error?: string }>;
   searchUsersAction?: (searchTerm: string) => Promise<User[]>;
   updateTaskAssignmentAction?: (
@@ -49,9 +49,9 @@ export default function Tasks({
   // Local state for tab filtering
   const [tabFilter, setTabFilter] = React.useState<string>("active");
 
-  const handleStatusUpdate = async (task: Task, newStatus: TaskStatus) => {
+  const handleStatusUpdate = async (task: TaskResponse, newStatus: TaskStatus) => {
     if (onTaskStatusUpdate) {
-      await onTaskStatusUpdate(task.id, newStatus);
+      await onTaskStatusUpdate(task.task_id, newStatus);
     }
   };
 
@@ -59,7 +59,9 @@ export default function Tasks({
   const filteredTasks = React.useMemo(() => {
     // First filter to only include tasks with valid statuses
     const validStatuses: TaskStatus[] = ["Not Started", "In Progress", "Completed", "Cancelled"];
-    const tasksWithValidStatus = tasks.filter(task => validStatuses.includes(task.status));
+    const tasksWithValidStatus = tasks.filter(task =>
+      validStatuses.includes(task.status as TaskStatus)
+    );
 
     // Then apply tab filtering
     switch (tabFilter) {
@@ -91,8 +93,8 @@ export default function Tasks({
     };
 
     return [...filteredTasks].sort((a, b) => {
-      const aOrder = statusOrder[a.status];
-      const bOrder = statusOrder[b.status];
+      const aOrder = statusOrder[a.status as TaskStatus];
+      const bOrder = statusOrder[b.status as TaskStatus];
 
       // Primary sort by status
       if (aOrder !== bOrder) {
@@ -329,7 +331,7 @@ export default function Tasks({
         >
           {sortedTasks.map(task => (
             <TaskCard
-              key={task.id}
+              key={task.task_id}
               task={task}
               onStatusUpdate={handleStatusUpdate}
               isUpdating={isUpdating}

--- a/frontend/src/lib/api/task.ts
+++ b/frontend/src/lib/api/task.ts
@@ -101,20 +101,13 @@ export async function createTask(taskData: {
   priority?: string;
   deadline: string;
   portfolio_id: number;
-  parent_task_id?: number;
-  source_meeting_id?: number;
-  status?: string;
 }): Promise<TaskResponse> {
-  const { status, ...rest } = taskData;
   return await apiFetch("/api/v1/tasks/", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      ...rest,
-      status: status ?? "Not Started",
-    }),
+    body: JSON.stringify(taskData),
   });
 }
 

--- a/frontend/src/lib/api/task.ts
+++ b/frontend/src/lib/api/task.ts
@@ -1,23 +1,17 @@
 import { getDirectorPortfolioId, isAdmin } from "@/lib/utils";
 import {
-  Portfolio,
-  PriorityLevel,
   RoleName,
-  Task,
   TaskCreatedByResponse,
   TaskResponse,
   TaskStatus,
   TaskUserAssignmentResponse,
   User,
-  UserTaskAssignment,
 } from "../types";
 import { apiFetch } from "./client";
-import { getPortfolioDetails } from "./portfolio";
 import { getRole } from "./role";
-import { Assignee } from "@/lib/types";
 
 // Server-side API function that works in server components
-export async function fetchUserTasks(): Promise<UserTaskAssignment[]> {
+export async function fetchUserTasks(): Promise<TaskResponse[]> {
   return await apiFetch("/api/v1/task-assignments/user/me/tasks", {
     method: "GET",
   });
@@ -77,7 +71,7 @@ export async function updateTaskStatus(taskId: number, status: string): Promise<
 }
 
 // General task update function
-export async function updateTask(taskId: number, updates: Partial<Task>): Promise<TaskResponse> {
+export async function updateTask(taskId: number, updates: Partial<TaskResponse>): Promise<TaskResponse> {
   return await apiFetch(`/api/v1/tasks/${taskId}`, {
     method: "PUT",
     headers: {
@@ -101,7 +95,6 @@ export async function getPendingTasksByMeeting(meetingId: number): Promise<TaskR
   });
 }
 
-// Create a new task
 export async function createTask(taskData: {
   title: string;
   description?: string;
@@ -125,157 +118,14 @@ export async function createTask(taskData: {
   });
 }
 
-// Delete a task
 export async function deleteTask(taskId: number): Promise<void> {
   return await apiFetch(`/api/v1/tasks/${taskId}`, {
     method: "DELETE",
   });
 }
 
-// Improved transformation that handles errors gracefully
-export const transformUserTaskToTask = async (userTask: UserTaskAssignment): Promise<Task> => {
-  // Essential data that we must have
-  let portfolioDetails;
-  try {
-    portfolioDetails = await getPortfolioDetails(userTask.task_portfolio_id);
-  } catch (error) {
-    console.warn(`Failed to get portfolio details for task ${userTask.task_id}:`, error);
-    portfolioDetails = { name: "Unknown Portfolio" };
-  }
-
-  // Optional data - handle failures gracefully
-  let assignees: Assignee[] = [];
-  try {
-    const assigneesData = await getTaskAssignees(userTask.task_id);
-    assignees = assigneesData.map(assignee => ({
-      id: assignee.user_id,
-      name: assignee.user_username,
-      email: assignee.user_email,
-    }));
-  } catch (error) {
-    console.warn(`Failed to get assignees for task ${userTask.task_id}:`, error);
-    assignees = [];
-  }
-
-  let creator: TaskCreatedByResponse;
-  try {
-    creator = await getTaskCreator(userTask.task_id);
-  } catch (error) {
-    console.warn(`Failed to get creator for task ${userTask.task_id}:`, error);
-    creator = {
-      user_id: 0,
-      username: "Unknown",
-      email: "unknown@example.com",
-    };
-  }
-
-  let subtasks: Task[] = [];
-  try {
-    const subtasksData = await getSubtasks(userTask.task_id);
-    // For subtasks, we'll use a simpler approach to avoid recursive errors
-    subtasks = await Promise.all(
-      subtasksData.map(async subtask => {
-        let subtaskCreator: TaskCreatedByResponse;
-        try {
-          subtaskCreator = await getTaskCreator(subtask.task_id);
-        } catch {
-          subtaskCreator = {
-            user_id: 0,
-            username: "Unknown",
-            email: "unknown@example.com",
-          };
-        }
-
-        return {
-          id: subtask.task_id,
-          title: subtask.title,
-          description: subtask.description,
-          status: subtask.status as TaskStatus,
-          priority: subtask.priority as PriorityLevel,
-          deadline: subtask.deadline,
-          created_at: subtask.created_at,
-          updated_at: subtask.updated_at,
-          created_by: subtaskCreator,
-          portfolio_id: subtask.portfolio_id,
-          portfolio: portfolioDetails.name as Portfolio,
-          assignees: [], // Skip assignees for subtasks to avoid more API calls
-          subtasks: [], // No nested subtasks to avoid infinite recursion
-        };
-      })
-    );
-  } catch (error) {
-    console.warn(`Failed to get subtasks for task ${userTask.task_id}:`, error);
-    subtasks = [];
-  }
-
-  return {
-    id: userTask.task_id,
-    title: userTask.task_title,
-    portfolio: portfolioDetails.name as Portfolio,
-    description: userTask.task_description,
-    created_at: userTask.task_created_at,
-    updated_at: userTask.task_updated_at,
-    priority: userTask.task_priority as PriorityLevel,
-    deadline: userTask.task_deadline,
-    status: userTask.task_status as TaskStatus,
-    portfolio_id: userTask.task_portfolio_id,
-    subtasks: subtasks,
-    assignees: assignees,
-    created_by: creator,
-  };
-};
-
-export const transformTaskResponseToTask = async (taskResponse: TaskResponse): Promise<Task> => {
-  const taskDetails = await getTaskDetails(taskResponse.task_id);
-  const assigneesData = await getTaskAssignees(taskResponse.task_id);
-  const assignees = assigneesData.map(assignee => ({
-    id: assignee.user_id,
-    name: assignee.user_username,
-    email: assignee.user_email,
-  }));
-  const creator = await getTaskCreator(taskResponse.task_id);
-  const portfolioDetails = await getPortfolioDetails(taskResponse.portfolio_id);
-  const subtasksData = await getSubtasks(taskResponse.task_id);
-  const subtasks = await Promise.all(
-    subtasksData.map(async subtask => {
-      const subtaskCreator = await getTaskCreator(subtask.task_id);
-      return {
-        id: subtask.task_id,
-        title: subtask.title,
-        description: subtask.description,
-        status: subtask.status as TaskStatus,
-        priority: subtask.priority as PriorityLevel,
-        deadline: subtask.deadline,
-        created_at: subtask.created_at,
-        updated_at: subtask.updated_at,
-        created_by: subtaskCreator,
-        portfolio_id: subtask.portfolio_id,
-        portfolio: portfolioDetails.name as Portfolio,
-        assignees: [], // assignees for subtasks
-        subtasks: [], // subtasks of subtasks
-      };
-    })
-  );
-  return {
-    id: taskResponse.task_id,
-    title: taskResponse.title,
-    description: taskResponse.description,
-    status: taskResponse.status as TaskStatus,
-    priority: taskResponse.priority as PriorityLevel,
-    deadline: taskResponse.deadline,
-    created_at: taskDetails.created_at,
-    updated_at: taskDetails.updated_at,
-    created_by: creator,
-    portfolio_id: taskResponse.portfolio_id,
-    portfolio: portfolioDetails.name as Portfolio,
-    assignees: assignees,
-    subtasks: subtasks,
-  };
-};
-
 export async function getUserTasksWithRole(user: User, targetStatus?: TaskStatus | null) {
   try {
-    // Get user role
     const role = await getRole(user.role_id);
     const roleName = role.role_name as RoleName;
     const directorPortfolioId = getDirectorPortfolioId(roleName, user);
@@ -283,16 +133,13 @@ export async function getUserTasksWithRole(user: User, targetStatus?: TaskStatus
     const showMyTasks = !directorPortfolioId && !userIsAdmin;
 
     // Load tasks based on role
-    let allTasks: Task[] = [];
+    let allTasks: TaskResponse[] = [];
     if (directorPortfolioId) {
-      const portfolioTasks = await fetchTasksByPortfolio(directorPortfolioId);
-      allTasks = await Promise.all(portfolioTasks.map(transformTaskResponseToTask));
+      allTasks = await fetchTasksByPortfolio(directorPortfolioId);
     } else if (userIsAdmin) {
-      const adminTasks = await fetchAllTasks();
-      allTasks = await Promise.all(adminTasks.map(transformTaskResponseToTask));
+      allTasks = await fetchAllTasks();
     } else {
-      const userTasks = await fetchUserTasks();
-      allTasks = await Promise.all(userTasks.map(transformUserTaskToTask));
+      allTasks = await fetchUserTasks();
     }
 
     // Filter by status if specified

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -138,21 +138,6 @@ export interface User {
   avatar?: string;
 }
 
-export interface UserTaskAssignment {
-  assignment_id: number;
-  task_id: number;
-  task_title: string;
-  task_description: string;
-  task_status: string;
-  task_priority: string;
-  task_deadline: string;
-  task_portfolio_id: number;
-  task_parent_task_id: number;
-  task_source_meeting_id: number;
-  task_created_at: string;
-  task_updated_at: string;
-}
-
 // Task update interface to match backend TaskUpdate
 export interface TaskUpdateRequest {
   title?: string;
@@ -164,6 +149,7 @@ export interface TaskUpdateRequest {
   parent_task_id?: number;
   source_meeting_id?: number;
 }
+
 export interface TaskResponse {
   task_id: number;
   title: string;
@@ -171,19 +157,24 @@ export interface TaskResponse {
   status: string;
   priority: string;
   deadline: string;
-  portfolio_id: number;
+  portfolio: {
+    portfolio_id: number;
+    name: string;
+  };
   parent_task_id: number;
   source_meeting_id: number;
   created_at: string;
   updated_at: string;
-  created_by: number;
+  created_by: TaskCreatedByResponse;
+  subtasks: TaskResponse[];
+  assignees: TaskUserAssignmentResponse[];
 }
 
 export interface TaskUserAssignmentResponse {
   assignment_id: number;
   user_id: number;
-  user_username: string;
-  user_email: string;
+  username: string;
+  email: string;
 }
 
 export interface TaskCreatedByResponse {
@@ -237,7 +228,7 @@ export interface PortfolioSimple {
   portfolio_id: number;
   name: string;
   description?: string;
-  has_channel: boolean;
+  has_channel?: boolean;
 }
 
 export interface Role {


### PR DESCRIPTION
Backend: refactor task assignment and task retrieval endpoints to use TaskListResponse schema

- Updated the read_my_assigned_tasks and read_user_assigned_tasks endpoints to return TaskListResponse instead of UserTaskAssignmentResponse.
- Refactored task_assignment CRUD functions to improve data retrieval and response formatting.
- Enhanced task retrieval functions to include subtasks and related user information.
- Adjusted task schemas to align with new response structures.

Frontend: refactor task components to use TaskResponse schema in frontend

- Updated TaskCard, TaskConfirmationClient, and TaskDashboardClient components to utilize TaskResponse instead of Task.
- Adjusted task assignment and update functions to align with the new schema.
- Enhanced task fetching logic to streamline data handling and improve performance.
- Removed obsolete transformation functions for task data.