### PR TITLE
Fix meeting recording command by specifying portfolio_id type

### DIFF
--- a/taskbot/cogs/meeting_record.py
+++ b/taskbot/cogs/meeting_record.py
@@ -84,6 +84,7 @@ class MeetingRecord(commands.Cog):
         ctx: discord.ApplicationContext,
         meeting_name = discord.Option(str, "Meeting name", required=True),
         portfolio_id = discord.Option(
+            int,
             description="Select the portfolio for this meeting",
             required=True,
             choices=portfolio_options


### PR DESCRIPTION
- Updated the portfolio_id option in the start_recording command to explicitly define its type as an integer, improving type safety and clarity for users.